### PR TITLE
Add FATT models

### DIFF
--- a/common/models/accesss-log.js
+++ b/common/models/accesss-log.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(Accessslog) {
+
+};

--- a/common/models/accesss-log.json
+++ b/common/models/accesss-log.json
@@ -1,0 +1,35 @@
+{
+  "name": "accesssLog",
+  "plural": "accessLogs",
+  "base": "PersistedModel",
+  "idInjection": true,
+  "options": {
+    "validateUpsert": true
+  },
+  "properties": {
+    "timestamp": {
+      "type": "date",
+      "required": true
+    },
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "rfid": {
+      "type": "number",
+      "required": true
+    },
+    "location": {
+      "type": "string",
+      "required": true
+    },
+    "result": {
+      "type": "number",
+      "required": true
+    }
+  },
+  "validations": [],
+  "relations": {},
+  "acls": [],
+  "methods": {}
+}

--- a/common/models/cert.js
+++ b/common/models/cert.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(Cert) {
+
+};

--- a/common/models/cert.json
+++ b/common/models/cert.json
@@ -12,7 +12,9 @@
       "required": true
     },
     "rfid": {
-      "type": "number",
+      "type": [
+        "number"
+      ],
       "required": true
     }
   },

--- a/common/models/cert.json
+++ b/common/models/cert.json
@@ -1,0 +1,23 @@
+{
+  "name": "cert",
+  "plural": "certs",
+  "base": "PersistedModel",
+  "idInjection": true,
+  "options": {
+    "validateUpsert": true
+  },
+  "properties": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "rfid": {
+      "type": "number",
+      "required": true
+    }
+  },
+  "validations": [],
+  "relations": {},
+  "acls": [],
+  "methods": {}
+}

--- a/common/models/member.json
+++ b/common/models/member.json
@@ -8,7 +8,9 @@
   },
   "properties": {
     "fob": {
-      "type": "number",
+      "type": [
+        "number"
+      ],
       "required": true
     },
     "name": {

--- a/common/models/member.json
+++ b/common/models/member.json
@@ -8,7 +8,7 @@
   },
   "properties": {
     "fob": {
-      "type": "string",
+      "type": "number",
       "required": true
     },
     "name": {

--- a/documentation/adding-a-model.md
+++ b/documentation/adding-a-model.md
@@ -1,0 +1,8 @@
+Basic guide on adding a data model to the AMT-API:
+
+1. Follow the steps described in adjacent file `setup.md`
+2. Run `npm install -g loopback-cli` to install the development command line tools on your machine
+3. Run `lb model` to initialize the model creation wizard
+4. Follow the steps in the model creation wizard. It begins by asking for general information on the new model. The datasource should be `db (mongodb)`, the base class should be `PersistedModel`. Most models should be set to `common`. You can then add properties as needed. End the creation process by entering an empty model.
+5. Observe new files created in the `/common/models` folder. You can make edits if needed by changing these files.
+6. Test your new model by running the application.

--- a/documentation/editing-a-model.md
+++ b/documentation/editing-a-model.md
@@ -1,0 +1,10 @@
+Basic guide in editing an existing model in the AMT-API:
+
+Note: It may be helpful to first practice with creating a model, even if your eventual goal is to just edit an existing record. See adjacent file `adding-a-model.md` for instructions on how to add a new model.
+
+1. Follow the steps described in adjacent file `setup.md`
+2. Run `npm install -g loopback-cli` to install the development command line tools on your machine
+3. Run `lb property` to initialize the model editing wizard
+4. Follow the prompts in the wizard. Be sure to be precise with the model and column names that you choose, the tool operates purely on strings. You can edit multiple models by running the tool multiple times.
+5. Observe that the wizard changes the JSON definition files in the `/common/models` folder.
+6. Test your new models by running the application.

--- a/documentation/setup.md
+++ b/documentation/setup.md
@@ -12,5 +12,5 @@ This dramatically reduces the amount of work that developers have to do to get t
 
 # Deployment
 
-This project will be dockerized, eventually. We should also dockerize the database container.
+This project uses docker. See the accompanying deployment repository for the docker-compose file used in production. Ensure that the docker file in this repository remains compatible with that setup.
 

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -46,5 +46,13 @@
   "bill": {
     "dataSource": "db",
     "public": true
+  },
+  "cert": {
+    "dataSource": "db",
+    "public": true
+  },
+  "accesssLog": {
+    "dataSource": "db",
+    "public": true
   }
 }


### PR DESCRIPTION
Add models for FATT project use as discussed on slack.

Also includes documentation on how to make a model, in case someone else wants to do it for themselves.

Follows this suggestion:
```
- cert model: POST /cert  {  'name':str, rfids: ['rfid', ...] },
- user: POST /user {'id': 0, 'rfids': [01235,...], 'name': 'someone'}
- log:  POST /log {'timestamp': "YYYY-mm-dd HH:MM:SS...", name: "someone", rfid: "012345", location: "lamp",  result: 200}
```